### PR TITLE
[2024/07/25] feature/CU-32_websocket-message

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,8 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    //websocket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
 //    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.0'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'

--- a/src/main/java/com/team9oogling/codyus/domain/chatting/config/StompHandler.java
+++ b/src/main/java/com/team9oogling/codyus/domain/chatting/config/StompHandler.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Component;
 
 import com.team9oogling.codyus.global.jwt.JwtProvider;
 
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -29,7 +28,7 @@ public class StompHandler implements ChannelInterceptor {
 			try {
 				// Authorization 헤더에서 Bearer 토큰을 추출
 				String token = accessor.getFirstNativeHeader("Authorization");
-				if(token != null && token.startsWith("Bearer ")) {
+				if (token != null && token.startsWith("Bearer ")) {
 					log.info("Token => {}", token);
 
 					token = token.substring(7); // 'Bearer ' 제거

--- a/src/main/java/com/team9oogling/codyus/domain/chatting/config/StompHandler.java
+++ b/src/main/java/com/team9oogling/codyus/domain/chatting/config/StompHandler.java
@@ -1,0 +1,45 @@
+package com.team9oogling.codyus.domain.chatting.config;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.stereotype.Component;
+
+import com.team9oogling.codyus.global.jwt.JwtProvider;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class StompHandler implements ChannelInterceptor {
+
+	private final JwtProvider jwtProvider;
+
+	@Override
+	public Message<?> preSend(Message<?> message, MessageChannel channel) {
+		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+
+		if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+			log.info("connect" + " 연결");
+			try {
+				// Authorization 헤더에서 Bearer 토큰을 추출
+				String token = accessor.getFirstNativeHeader("Authorization");
+				if(token != null && token.startsWith("Bearer ")) {
+					log.info("Token => {}", token);
+
+					token = token.substring(7); // 'Bearer ' 제거
+					jwtProvider.getClaimsFromToken(token);
+				}
+			} catch (Exception e) {
+				throw new RuntimeException("연결 안됨!!");
+			}
+		}
+
+		return message;
+	}
+}

--- a/src/main/java/com/team9oogling/codyus/domain/chatting/config/webSocketConfig.java
+++ b/src/main/java/com/team9oogling/codyus/domain/chatting/config/webSocketConfig.java
@@ -1,0 +1,36 @@
+package com.team9oogling.codyus.domain.chatting.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class webSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+	private final StompHandler stompHandler;
+
+	@Override
+	public void registerStompEndpoints(final StompEndpointRegistry registry) {
+		// STOP 엔드포인트 등록 클라이언트는 이 엔드 포인트를 통해 서버와 연결
+		registry.addEndpoint("/chatting").setAllowedOrigins("http://localhost:8080").withSockJS();
+	}
+
+	@Override
+	public void configureMessageBroker(final MessageBrokerRegistry config) {
+		/* 메세지 브로커를 설정합니다. 클라이언트가 메시지를 구독할 수 있는 엔드포인트를 정의합니다. */
+		config.enableSimpleBroker("/topic"); // 클라이언트가 구독할 브로커 엔드포인트
+		config.setApplicationDestinationPrefixes("/app"); // 클라이언트가 메시지를 전송할 때 사용하는 접두사
+	}
+
+	@Override
+	public void configureClientInboundChannel(ChannelRegistration registration){
+		registration.interceptors(stompHandler);
+	}
+}

--- a/src/main/java/com/team9oogling/codyus/domain/chatting/controller/ChattingRoomController.java
+++ b/src/main/java/com/team9oogling/codyus/domain/chatting/controller/ChattingRoomController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.team9oogling.codyus.domain.chatting.dto.ChattingRoomCreateResponseDto;
 import com.team9oogling.codyus.domain.chatting.service.ChattingRoomService;
+import com.team9oogling.codyus.global.entity.ResponseFactory;
 import com.team9oogling.codyus.global.security.UserDetailsImpl;
 import com.team9oogling.codyus.global.dto.DataResponseDto;
 
@@ -25,15 +26,10 @@ public class ChattingRoomController {
 
 	@PostMapping("/post/{postId}/chattingrooms")
 	public ResponseEntity<DataResponseDto<ChattingRoomCreateResponseDto>> createChattingRoom(@PathVariable Long postId,
-		@AuthenticationPrincipal
-		UserDetailsImpl userDetails) {
+		@AuthenticationPrincipal UserDetailsImpl userDetails ) {
 		ChattingRoomCreateResponseDto responseDto = chattingRoomService.createChattingRoom(postId,
-			userDetails.getUser());
-		return ResponseEntity.ok(
-			new DataResponseDto<>(
-				SUCCESS_CREATE_CHATTINGROOMS.getStatus(),
-				SUCCESS_CREATE_CHATTINGROOMS.getMessage(),
-				responseDto
-			));
+			userDetails);
+		return ResponseFactory.ok(responseDto, SUCCESS_CREATE_CHATTINGROOMS);
+
 	}
 }

--- a/src/main/java/com/team9oogling/codyus/domain/chatting/controller/ChattingRoomController.java
+++ b/src/main/java/com/team9oogling/codyus/domain/chatting/controller/ChattingRoomController.java
@@ -11,9 +11,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.team9oogling.codyus.domain.chatting.dto.ChattingRoomCreateResponseDto;
 import com.team9oogling.codyus.domain.chatting.service.ChattingRoomService;
+import com.team9oogling.codyus.global.dto.DataResponseDto;
 import com.team9oogling.codyus.global.entity.ResponseFactory;
 import com.team9oogling.codyus.global.security.UserDetailsImpl;
-import com.team9oogling.codyus.global.dto.DataResponseDto;
 
 import lombok.RequiredArgsConstructor;
 
@@ -26,9 +26,8 @@ public class ChattingRoomController {
 
 	@PostMapping("/post/{postId}/chattingrooms")
 	public ResponseEntity<DataResponseDto<ChattingRoomCreateResponseDto>> createChattingRoom(@PathVariable Long postId,
-		@AuthenticationPrincipal UserDetailsImpl userDetails ) {
-		ChattingRoomCreateResponseDto responseDto = chattingRoomService.createChattingRoom(postId,
-			userDetails);
+		@AuthenticationPrincipal UserDetailsImpl userDetails) {
+		ChattingRoomCreateResponseDto responseDto = chattingRoomService.createChattingRoom(postId, userDetails);
 		return ResponseFactory.ok(responseDto, SUCCESS_CREATE_CHATTINGROOMS);
 
 	}

--- a/src/main/java/com/team9oogling/codyus/domain/chatting/controller/MessageController.java
+++ b/src/main/java/com/team9oogling/codyus/domain/chatting/controller/MessageController.java
@@ -1,0 +1,21 @@
+package com.team9oogling.codyus.domain.chatting.controller;
+
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.stereotype.Controller;
+
+import com.team9oogling.codyus.domain.chatting.dto.ChattingMessageRequestDto;
+import com.team9oogling.codyus.domain.chatting.service.MessageService;
+
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequiredArgsConstructor
+public class MessageController {
+
+	private final MessageService messageService;
+
+	@MessageMapping("/message")
+	public void sendMessage(final ChattingMessageRequestDto requestDto) {
+		messageService.sendMessage(requestDto);
+	}
+}

--- a/src/main/java/com/team9oogling/codyus/domain/chatting/dto/ChattingMessageRequestDto.java
+++ b/src/main/java/com/team9oogling/codyus/domain/chatting/dto/ChattingMessageRequestDto.java
@@ -1,0 +1,17 @@
+package com.team9oogling.codyus.domain.chatting.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ChattingMessageRequestDto {
+	private String token;
+	private Long chattingRoomId;
+	private String message;
+
+	public String getToken(){
+		if(null != token && token.startsWith("Bearer ")) {
+			return token.substring(7);
+		}
+		return token;
+	}
+}

--- a/src/main/java/com/team9oogling/codyus/domain/chatting/dto/ChattingMessageResponseDto.java
+++ b/src/main/java/com/team9oogling/codyus/domain/chatting/dto/ChattingMessageResponseDto.java
@@ -1,0 +1,25 @@
+package com.team9oogling.codyus.domain.chatting.dto;
+
+import java.time.LocalDateTime;
+
+import com.team9oogling.codyus.domain.chatting.entity.Message;
+
+import lombok.Getter;
+
+@Getter
+public class ChattingMessageResponseDto {
+
+	private final Long messageId;
+	private final String message;
+	private final String nickName;
+	private final String token;
+	private final LocalDateTime timestamp;
+
+	public ChattingMessageResponseDto(String token, final Message message) {
+		this.messageId = message.getId();
+		this.message = message.getMessage();
+		this.token = token;
+		this.nickName = message.getUser().getNickname();
+		this.timestamp = message.getCreatedAt();
+	}
+}

--- a/src/main/java/com/team9oogling/codyus/domain/chatting/entity/ChattingMember.java
+++ b/src/main/java/com/team9oogling/codyus/domain/chatting/entity/ChattingMember.java
@@ -3,9 +3,7 @@ package com.team9oogling.codyus.domain.chatting.entity;
 import com.team9oogling.codyus.domain.user.entity.User;
 import com.team9oogling.codyus.global.entity.Timestamped;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -20,7 +18,7 @@ import lombok.NoArgsConstructor;
 public class ChattingMember extends Timestamped {
 
 	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY )
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
 	@ManyToOne

--- a/src/main/java/com/team9oogling/codyus/domain/chatting/entity/Message.java
+++ b/src/main/java/com/team9oogling/codyus/domain/chatting/entity/Message.java
@@ -29,8 +29,8 @@ public class Message extends Timestamped {
 
 	private String message;
 
-	public Message(ChattingMember member, ChattingMessageRequestDto requestDto) {
-		user = member.getUser();
+	public Message(User user, ChattingMember member,ChattingMessageRequestDto requestDto) {
+		this.user = user;
 		this.chattingMember = member;
 		this.message = requestDto.getMessage();
 	}

--- a/src/main/java/com/team9oogling/codyus/domain/chatting/entity/Message.java
+++ b/src/main/java/com/team9oogling/codyus/domain/chatting/entity/Message.java
@@ -29,7 +29,7 @@ public class Message extends Timestamped {
 
 	private String message;
 
-	public Message(User user, ChattingMember member,ChattingMessageRequestDto requestDto) {
+	public Message(User user, ChattingMember member, ChattingMessageRequestDto requestDto) {
 		this.user = user;
 		this.chattingMember = member;
 		this.message = requestDto.getMessage();

--- a/src/main/java/com/team9oogling/codyus/domain/chatting/entity/MessageOffset.java
+++ b/src/main/java/com/team9oogling/codyus/domain/chatting/entity/MessageOffset.java
@@ -1,6 +1,5 @@
 package com.team9oogling.codyus.domain.chatting.entity;
 
-import com.team9oogling.codyus.domain.chatting.dto.ChattingMessageRequestDto;
 import com.team9oogling.codyus.domain.user.entity.User;
 import com.team9oogling.codyus.global.entity.Timestamped;
 
@@ -8,31 +7,34 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Getter
 @NoArgsConstructor
-public class Message extends Timestamped {
+@Getter
+public class MessageOffset extends Timestamped {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@ManyToOne
-	private User user;
+	private Long lastReadMessageId;
 
-	@ManyToOne
-	private ChattingMember chattingMember;
+	private Long chattingRoomId;
 
-	private String message;
+	private Long userId;
 
-	public Message(ChattingMember member, ChattingMessageRequestDto requestDto) {
-		user = member.getUser();
-		this.chattingMember = member;
-		this.message = requestDto.getMessage();
+	public MessageOffset(Message message) {
+		this.lastReadMessageId = message.getId();
 	}
 
+	public MessageOffset(User user, ChattingRoom chattingRoom) {
+		this.chattingRoomId = chattingRoom.getId();
+		this.userId = user.getId();
+	}
+
+	public void updateOffset(Message message) {
+		this.lastReadMessageId = message.getId();
+	}
 }

--- a/src/main/java/com/team9oogling/codyus/domain/chatting/repository/ChattingMemberRepository.java
+++ b/src/main/java/com/team9oogling/codyus/domain/chatting/repository/ChattingMemberRepository.java
@@ -8,5 +8,6 @@ import com.team9oogling.codyus.domain.user.entity.User;
 
 public interface ChattingMemberRepository extends JpaRepository<ChattingMember, Long> {
 	boolean existsByChattingRoomAndUser(ChattingRoom room, User user);
+
 	ChattingMember findByChattingRoom(ChattingRoom room);
 }

--- a/src/main/java/com/team9oogling/codyus/domain/chatting/repository/ChattingMemberRepository.java
+++ b/src/main/java/com/team9oogling/codyus/domain/chatting/repository/ChattingMemberRepository.java
@@ -8,4 +8,5 @@ import com.team9oogling.codyus.domain.user.entity.User;
 
 public interface ChattingMemberRepository extends JpaRepository<ChattingMember, Long> {
 	boolean existsByChattingRoomAndUser(ChattingRoom room, User user);
+	ChattingMember findByChattingRoom(ChattingRoom room);
 }

--- a/src/main/java/com/team9oogling/codyus/domain/chatting/repository/MessageOffsetRepository.java
+++ b/src/main/java/com/team9oogling/codyus/domain/chatting/repository/MessageOffsetRepository.java
@@ -1,0 +1,11 @@
+package com.team9oogling.codyus.domain.chatting.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.team9oogling.codyus.domain.chatting.entity.MessageOffset;
+
+public interface MessageOffsetRepository extends JpaRepository<MessageOffset, Long> {
+	Optional<MessageOffset> findByChattingRoomIdAndUserId(Long chattingRoomId, Long userId);
+}

--- a/src/main/java/com/team9oogling/codyus/domain/chatting/service/ChattingRoomService.java
+++ b/src/main/java/com/team9oogling/codyus/domain/chatting/service/ChattingRoomService.java
@@ -39,7 +39,7 @@ public class ChattingRoomService {
 		User user = userDetails.getUser();
 		Post post = postService.findById(postId);
 
-		if(Objects.equals(post.getUser().getId(), user.getId())) {
+		if (Objects.equals(post.getUser().getId(), user.getId())) {
 			throw new CustomException(SAME_USERID_POST_USERID);
 		}
 		ChattingRoomPostAndUser(postId, user);

--- a/src/main/java/com/team9oogling/codyus/domain/chatting/service/ChattingRoomService.java
+++ b/src/main/java/com/team9oogling/codyus/domain/chatting/service/ChattingRoomService.java
@@ -10,12 +10,15 @@ import org.springframework.transaction.annotation.Transactional;
 import com.team9oogling.codyus.domain.chatting.dto.ChattingRoomCreateResponseDto;
 import com.team9oogling.codyus.domain.chatting.entity.ChattingMember;
 import com.team9oogling.codyus.domain.chatting.entity.ChattingRoom;
+import com.team9oogling.codyus.domain.chatting.entity.MessageOffset;
 import com.team9oogling.codyus.domain.chatting.repository.ChattingMemberRepository;
 import com.team9oogling.codyus.domain.chatting.repository.ChattingRoomRepository;
+import com.team9oogling.codyus.domain.chatting.repository.MessageOffsetRepository;
 import com.team9oogling.codyus.domain.post.entity.Post;
-import com.team9oogling.codyus.domain.post.repository.PostRepository;
+import com.team9oogling.codyus.domain.post.service.PostService;
 import com.team9oogling.codyus.domain.user.entity.User;
 import com.team9oogling.codyus.global.exception.CustomException;
+import com.team9oogling.codyus.global.security.UserDetailsImpl;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,26 +30,29 @@ public class ChattingRoomService {
 
 	private final ChattingRoomRepository chattingRoomRepository;
 	private final ChattingMemberRepository chattingMemberRepository;
+	private final MessageOffsetRepository messageOffsetRepository;
 
-	private final PostRepository postRepository;
+	private final PostService postService;
+
 	@Transactional
-	public ChattingRoomCreateResponseDto createChattingRoom(Long postId, User user) {
-		Post post = postRepository.findById(postId).orElse(null); // -> PostService.PostfindById 로 바꿀예정
-		if(post == null) {
-			throw new CustomException(NOT_FOUND_POST);
-		}
+	public ChattingRoomCreateResponseDto createChattingRoom(Long postId, UserDetailsImpl userDetails) {
+		User user = userDetails.getUser();
+		Post post = postService.findById(postId);
 
-//		if(Objects.equals(post.getUser().getId(), user.getId())) {
-//			throw new CustomException(SAME_USERID_POST_USERID);
-//		}
+		if(Objects.equals(post.getUser().getId(), user.getId())) {
+			throw new CustomException(SAME_USERID_POST_USERID);
+		}
 		ChattingRoomPostAndUser(postId, user);
 
 		ChattingRoom chattingRoom = new ChattingRoom(post);
-		ChattingMember chattingMember = new ChattingMember(user, chattingRoom);
-
 		chattingRoomRepository.save(chattingRoom);
-		chattingRoom.addMember(chattingMember);
+		ChattingMember chattingMember = new ChattingMember(user, chattingRoom);
 		chattingMemberRepository.save(chattingMember);
+		chattingRoom.addMember(chattingMember);
+		MessageOffset messageOffset = new MessageOffset(user, chattingRoom);
+		MessageOffset messageOffsetPostUser = new MessageOffset(post.getUser(), chattingRoom);
+		messageOffsetRepository.save(messageOffset);
+		messageOffsetRepository.save(messageOffsetPostUser);
 
 		return new ChattingRoomCreateResponseDto(chattingRoom.getId(), post);
 	}
@@ -59,5 +65,11 @@ public class ChattingRoomService {
 		if (isChattingRoom) {
 			throw new CustomException(ALREADY_CHATTINGROOMS_EXISTS);
 		}
+	}
+
+	public ChattingRoom ChattingRoomFindById(Long ChattingRoomId) {
+		return chattingRoomRepository.findById(ChattingRoomId).orElseThrow(
+			() -> new CustomException(NOT_FOUND_CHATTINGROOMS)
+		);
 	}
 }

--- a/src/main/java/com/team9oogling/codyus/domain/chatting/service/MessageService.java
+++ b/src/main/java/com/team9oogling/codyus/domain/chatting/service/MessageService.java
@@ -1,0 +1,73 @@
+package com.team9oogling.codyus.domain.chatting.service;
+
+import static com.team9oogling.codyus.global.entity.StatusCode.*;
+
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.team9oogling.codyus.domain.chatting.dto.ChattingMessageRequestDto;
+import com.team9oogling.codyus.domain.chatting.dto.ChattingMessageResponseDto;
+import com.team9oogling.codyus.domain.chatting.entity.ChattingMember;
+import com.team9oogling.codyus.domain.chatting.entity.ChattingRoom;
+import com.team9oogling.codyus.domain.chatting.entity.Message;
+import com.team9oogling.codyus.domain.chatting.entity.MessageOffset;
+import com.team9oogling.codyus.domain.chatting.repository.ChattingMemberRepository;
+import com.team9oogling.codyus.domain.chatting.repository.MessageOffsetRepository;
+import com.team9oogling.codyus.domain.chatting.repository.MessageRepository;
+import com.team9oogling.codyus.domain.user.entity.User;
+import com.team9oogling.codyus.domain.user.service.UserService;
+import com.team9oogling.codyus.global.exception.CustomException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MessageService {
+
+	private final MessageRepository messageRepository;
+	private final ChattingMemberRepository chattingMemberRepository;
+	private final MessageOffsetRepository messageOffsetRepository;
+
+	private final ChattingRoomService chattingRoomService;
+	private final UserService userService;
+
+	private final SimpMessageSendingOperations messagingTemplate;
+
+	@Transactional
+	public ChattingMessageResponseDto sendMessage(ChattingMessageRequestDto requestDto) {
+		User user = userService.findByToken(requestDto.getToken());
+
+		// 1. 채팅룸 존재  and 게시물이 닫혔는지 확인
+		ChattingRoom chattingRoom = chattingRoomService.ChattingRoomFindById(requestDto.getChattingRoomId());
+		// if (chattingRoom.getPost().getStatus().equals(PostStatus.COMPLETE)) {
+		// 	throw new CustomException(ITEM_TRANSACTION_COMPLETED);
+		// 	// 추후 변경
+		// }
+		// 2. 멤버 조회
+		ChattingMember member = chattingMemberRepository.findByChattingRoom(chattingRoom);
+
+		// 4. 메시지 처리
+		Message message = new Message(member, requestDto);
+		messageRepository.save(message);
+		// 생성되있으면 업데이트!!
+		updateMessageOffset(message, user, requestDto);
+
+		// 읽음 처리
+		ChattingMessageResponseDto responseDto = new ChattingMessageResponseDto(requestDto.getToken(), message);
+		/*
+		messagingTemplate.convertAndSend: 컨트롤러 메소드 내에서 직접 특정 경로(/topic/{chatRoomId})로 메시지를 전송합니다.
+		이를 통해 특정 채팅방에 관련된 클라이언트에게 메시지를 전송할 수 있습니다.
+		*/
+		messagingTemplate.convertAndSend("/topic/" + requestDto.getChattingRoomId(), responseDto);
+
+		return responseDto;
+	}
+
+	public void updateMessageOffset(Message message, User user, ChattingMessageRequestDto requestDto) {
+		MessageOffset messageOffset = messageOffsetRepository.findByChattingRoomIdAndUserId(
+				requestDto.getChattingRoomId(), user.getId())
+			.orElseThrow(() -> new CustomException(NOT_FOUND_MESSAGE_OFFSET));
+		messageOffset.updateOffset(message);
+	}
+}

--- a/src/main/java/com/team9oogling/codyus/domain/chatting/service/MessageService.java
+++ b/src/main/java/com/team9oogling/codyus/domain/chatting/service/MessageService.java
@@ -48,7 +48,7 @@ public class MessageService {
 		ChattingMember member = chattingMemberRepository.findByChattingRoom(chattingRoom);
 
 		// 4. 메시지 처리
-		Message message = new Message(member, requestDto);
+		Message message = new Message(user, member, requestDto);
 		messageRepository.save(message);
 		// 생성되있으면 업데이트!!
 		updateMessageOffset(message, user, requestDto);

--- a/src/main/java/com/team9oogling/codyus/domain/user/service/UserService.java
+++ b/src/main/java/com/team9oogling/codyus/domain/user/service/UserService.java
@@ -238,4 +238,8 @@ public class UserService {
     }
   }
 
+  public User findByToken(String token) {
+    String email = jwtProvider.getClaimsFromToken(token).getSubject();
+    return userRepository.findByEmail(email).orElseThrow(() -> new CustomException(StatusCode.NOT_FOUND_USER));
+  }
 }

--- a/src/main/java/com/team9oogling/codyus/global/config/SecurityConfig.java
+++ b/src/main/java/com/team9oogling/codyus/global/config/SecurityConfig.java
@@ -75,8 +75,7 @@ public class SecurityConfig {
             SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests((authorizeHttpRequests) -> authorizeHttpRequests
             .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
-            .requestMatchers("/api/users/signup", "/api/users/token/refresh", "/api/users/login")
-            .permitAll()
+            .requestMatchers("/chatting/**","chat.html","login.html","/api/users/signup", "/api/users/token/refresh", "/api/users/login").permitAll()
             .requestMatchers(HttpMethod.GET, "/api/users/login/kakao", "/api/users/kakao/callback",
                 "/api/users/login/naver", "/api/users/naver/callback", "/api/posts").permitAll()
             .requestMatchers("/api/admin/**").hasAuthority("ADMIN")
@@ -89,5 +88,4 @@ public class SecurityConfig {
 
     return http.build();
   }
-
 }

--- a/src/main/java/com/team9oogling/codyus/global/entity/StatusCode.java
+++ b/src/main/java/com/team9oogling/codyus/global/entity/StatusCode.java
@@ -1,8 +1,9 @@
 package com.team9oogling.codyus.global.entity;
 
+import org.springframework.http.HttpStatus;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.springframework.http.HttpStatus;
 
 @AllArgsConstructor
 @Getter
@@ -17,6 +18,7 @@ public enum StatusCode {
   SUCCESS_CREATE_CHATTINGROOMS(HttpStatus.CREATED, "채팅방 생성에 성공했습니다."),
   SUCCESS_ADD_LIKE(HttpStatus.CREATED, "좋아요를 눌렀습니다."),
   SUCCESS_DELETE_LIKE(HttpStatus.OK, "좋아요가 취소되었습니다."),
+  SUCCESS_SEND_MESSAGE(HttpStatus.OK, "메세지 전송에 성공했습니다."),
 
   // 400번대
   UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "접근 권한이 없습니다."),
@@ -36,7 +38,10 @@ public enum StatusCode {
 
   // Chatting
   NOT_FOUND_POST(HttpStatus.NOT_FOUND, "게시물이 없습니다."),
+  NOT_FOUND_CHATTINGROOMS(HttpStatus.NOT_FOUND, "채팅방 존재하지 않습니다."),
+  ITEM_TRANSACTION_COMPLETED(HttpStatus.CONFLICT, "이미 거래가 완료되었습니다."),
   SAME_USERID_POST_USERID(HttpStatus.CONFLICT, "게시물 작성 시 사용자 ID가 동일합니다."),
+  NOT_FOUND_MESSAGE_OFFSET(HttpStatus.NOT_FOUND, "메시지오프셋이 존재하지 않습니다."),
   ALREADY_CHATTINGROOMS_EXISTS(HttpStatus.CONFLICT, "이미 채팅방이 존재합니다.");
 
   private final HttpStatus status;


### PR DESCRIPTION
## #️⃣연관된 이슈

> CU-32

## 📝작업 내용

> feat : MessageOffSet 엔티티 생성 ( 읽음 상태 관리) 
    - 채팅방 생성시 저장
    -  메세지 보낼때마다 수정
    Message send 기능 추가
   UserService 에서 token 값으로 findByEmail 찾는 메서드 추가했습니다.!!
refactor : chattingRoom controller, service 리펙토링

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/ee2af475-dd1e-4ac1-8965-071de3f2c3f2)
채팅방 생성시 
![image](https://github.com/user-attachments/assets/dbb75277-ffc3-438a-972b-485158e0f8ca)
messageId 널값으로 오프셋 채팅유저 2명 추가

<br>
![image](https://github.com/user-attachments/assets/7fe3365c-2e1d-4858-b053-e327162758a2)

브라우저 
![image](https://github.com/user-attachments/assets/9085eec0-acfa-4b23-83a9-06d253980fae)


메세지 보내면
데이터베이스 
![image](https://github.com/user-attachments/assets/598fd915-56b3-4e66-be9b-59a38957b543)

![image](https://github.com/user-attachments/assets/d64daaf7-5148-49d3-a365-74ac7aca413d)
마지막에 보낸 메세지 수정해서 offset last_read_message_id 값에 들어갑니다.
