### PR TITLE
♻️refactor: 웹소켓 config setAllowedOrigins -> setAllowedOriginPatterns …

### DIFF
--- a/src/main/java/com/team9oogling/codyus/global/config/webSocketConfig.java
+++ b/src/main/java/com/team9oogling/codyus/global/config/webSocketConfig.java
@@ -19,7 +19,7 @@ public class webSocketConfig implements WebSocketMessageBrokerConfigurer {
 	@Override
 	public void registerStompEndpoints(final StompEndpointRegistry registry) {
 		// STOP 엔드포인트 등록 클라이언트는 이 엔드 포인트를 통해 서버와 연결
-		registry.addEndpoint("/chatting").setAllowedOrigins("*").withSockJS();
+		registry.addEndpoint("/chatting").setAllowedOriginPatterns("*").withSockJS();
 	}
 
 	@Override


### PR DESCRIPTION
## 📝작업 내용

> config setAllowedOrigins -> setAllowedOriginPatterns 로 변경

message
: 
"When allowCredentials is true, allowedOrigins cannot contain the special value \"*\" since that cannot be set on the \"Access-Control-Allow-Origin\" response header. To allow credentials to a set of origins, list them explicitly or consider using \"allowedOriginPatterns\" instead."
path
: 
"/chatting/510/mfblvpwk/xhr_streaming"
